### PR TITLE
mejoras en formulario de contacto: traducciones, validaciones y feedback inline

### DIFF
--- a/src/app/Contact.tsx
+++ b/src/app/Contact.tsx
@@ -1,54 +1,47 @@
 import { Mail, MapPin, Phone } from "lucide-react";
+import { useState } from "react";
 import { useTranslations } from "../context/translations/TranslationsProvider";
 import { sendEmail } from "./sendEmail";
 import Button from "../components/Button";
 
+type FormStatus = "idle" | "sending" | "success" | "error";
+
 const Contact = () => {
   const { translations: t } = useTranslations();
+  const [status, setStatus] = useState<FormStatus>("idle");
+  const [formError, setFormError] = useState<string | null>(null);
 
   const handleSubmitContact = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setFormError(null);
 
     const form = e.currentTarget;
-    const name = (
-      form.querySelector("#name") as HTMLInputElement
-    )?.value.trim();
-    const company = (
-      form.querySelector("#company") as HTMLInputElement
-    )?.value.trim();
-    const email = (
-      form.querySelector("#email") as HTMLInputElement
-    )?.value.trim();
-    const products = (form.querySelector("#products") as HTMLSelectElement)
-      ?.value;
-    const message = (
-      form.querySelector("#message") as HTMLTextAreaElement
-    )?.value.trim();
+    const name = (form.querySelector("#name") as HTMLInputElement)?.value.trim();
+    const company = (form.querySelector("#company") as HTMLInputElement)?.value.trim();
+    const email = (form.querySelector("#email") as HTMLInputElement)?.value.trim();
+    const products = (form.querySelector("#products") as HTMLSelectElement)?.value;
+    const message = (form.querySelector("#message") as HTMLTextAreaElement)?.value.trim();
 
     if (!name || !email || !products || !message) {
-      alert("Please fill in all required fields.");
+      setFormError(t.formFillRequired);
       return;
     }
 
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
-      alert("Please enter a valid email address.");
+      setFormError(t.formInvalidEmail);
       return;
     }
 
+    setStatus("sending");
     try {
       const formattedMessage = `Email enviado desde el formulario de contacto de la web.\n\nNombre: ${name}\nCompañía: ${company}\nEmail: ${email}\nProductos de interés: ${products}\nMensaje: ${message}`;
-      await sendEmail({
-        name,
-        email,
-        message: formattedMessage,
-      });
-
-      alert("Your message has been sent successfully!");
+      await sendEmail({ name, email, message: formattedMessage });
+      setStatus("success");
       form.reset();
     } catch (error) {
       console.error("Failed to send email:", error);
-      alert("There was an error sending your message. Please try again later.");
+      setStatus("error");
     }
   };
 
@@ -138,9 +131,9 @@ const Contact = () => {
                   <option value="lamb">{t.lamb}</option>
                   <option value="poultry">{t.poultry}</option>
                   <option value="dairy">{t.dairy}</option>
-                  <option value="horse">Horse Meat</option>
+                  <option value="horse">{t.horse}</option>
                   <option value="feed">{t.animalFeed}</option>
-                  <option value="multiple">Multiple Products</option>
+                  <option value="multiple">{t.multipleProducts}</option>
                 </select>
               </div>
               <div className="space-y-2">
@@ -154,7 +147,20 @@ const Contact = () => {
                   className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 ></textarea>
               </div>
-              <Button className="w-full">{t.sendMessage}</Button>
+
+              {formError && (
+                <p className="text-sm text-red-600">{formError}</p>
+              )}
+              {status === "success" && (
+                <p className="text-sm text-green-600">{t.formSuccess}</p>
+              )}
+              {status === "error" && (
+                <p className="text-sm text-red-600">{t.formError}</p>
+              )}
+
+              <Button className="w-full" disabled={status === "sending"}>
+                {status === "sending" ? t.formSending : t.sendMessage}
+              </Button>
             </form>
           </div>
         </div>

--- a/src/app/api/email/route.ts
+++ b/src/app/api/email/route.ts
@@ -2,16 +2,28 @@ import { type NextRequest, NextResponse } from "next/server";
 import nodemailer from "nodemailer";
 import Mail from "nodemailer/lib/mailer";
 
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const transport = nodemailer.createTransport({
+  service: "gmail",
+  auth: {
+    user: process.env.email,
+    pass: process.env.password,
+  },
+});
+
 export async function POST(request: NextRequest) {
   const { email, name, message } = await request.json();
 
-  const transport = nodemailer.createTransport({
-    service: "gmail",
-    auth: {
-      user: process.env.email,
-      pass: process.env.password,
-    },
-  });
+  if (!name || typeof name !== "string" || name.trim() === "") {
+    return NextResponse.json({ error: "Invalid name" }, { status: 400 });
+  }
+  if (!email || typeof email !== "string" || !emailRegex.test(email)) {
+    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
+  }
+  if (!message || typeof message !== "string" || message.trim() === "") {
+    return NextResponse.json({ error: "Invalid message" }, { status: 400 });
+  }
 
   const mailOptions: Mail.Options = {
     from: process.env.email,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,12 +6,14 @@ interface ButtonProps {
   children: React.ReactNode;
   variant?: "primary" | "secondary";
   className?: string;
+  disabled?: boolean;
 }
 
 const Button: React.FC<ButtonProps> = ({
   children,
   variant = "primary",
   className = "",
+  disabled = false,
 }) => {
   const baseStyle =
     "inline-block px-4 py-2 rounded-lg font-semibold transition-colors duration-200 cursor-pointer";
@@ -24,7 +26,10 @@ const Button: React.FC<ButtonProps> = ({
   };
 
   return (
-    <button className={`${baseStyle} ${variantStyles[variant]} ${className}`}>
+    <button
+      disabled={disabled}
+      className={`${baseStyle} ${variantStyles[variant]} ${className} disabled:opacity-50 disabled:cursor-not-allowed`}
+    >
       {children}
     </button>
   );

--- a/src/context/translations/cn.ts
+++ b/src/context/translations/cn.ts
@@ -188,6 +188,12 @@ const cn = {
   unitedStates: "美国",
   europeanUnion: "欧洲联盟",
   unitedKingdom: "英國",
-  philippines: "Philippines"
+  philippines: "Philippines",
+  multipleProducts: "多种产品",
+  formFillRequired: "请填写所有必填字段。",
+  formInvalidEmail: "请输入有效的电子邮件地址。",
+  formSuccess: "您的消息已成功发送！",
+  formError: "发送消息时出现错误，请稍后再试。",
+  formSending: "发送中...",
 } as const;
 export default cn;

--- a/src/context/translations/en.ts
+++ b/src/context/translations/en.ts
@@ -196,5 +196,11 @@ const en = {
   europeanUnion: "European Union",
   unitedKingdom: "United Kingdom",
   philippines: "Philippines",
+  multipleProducts: "Multiple Products",
+  formFillRequired: "Please fill in all required fields.",
+  formInvalidEmail: "Please enter a valid email address.",
+  formSuccess: "Your message has been sent successfully!",
+  formError: "There was an error sending your message. Please try again later.",
+  formSending: "Sending...",
 } as const;
 export default en;

--- a/src/context/translations/es.ts
+++ b/src/context/translations/es.ts
@@ -196,6 +196,12 @@ const es = {
   europeanUnion: "Unión Europea",
   unitedKingdom: "Reino Unido",
   philippines: "Filipinas",
+  multipleProducts: "Múltiples Productos",
+  formFillRequired: "Por favor completá todos los campos requeridos.",
+  formInvalidEmail: "Por favor ingresá una dirección de email válida.",
+  formSuccess: "¡Tu mensaje fue enviado con éxito!",
+  formError: "Hubo un error al enviar tu mensaje. Por favor intentá de nuevo.",
+  formSending: "Enviando...",
 } as const;
 
 export default es;

--- a/src/context/translations/ru.ts
+++ b/src/context/translations/ru.ts
@@ -193,6 +193,12 @@ const ru = {
   unitedStates: "Соединенные Штаты",
   europeanUnion: "Евросоюз",
   unitedKingdom: "Великобритания",
-  philippines: "Philippines"
+  philippines: "Philippines",
+  multipleProducts: "Несколько продуктов",
+  formFillRequired: "Пожалуйста, заполните все обязательные поля.",
+  formInvalidEmail: "Пожалуйста, введите корректный адрес электронной почты.",
+  formSuccess: "Ваше сообщение успешно отправлено!",
+  formError: "Произошла ошибка при отправке. Пожалуйста, попробуйте снова.",
+  formSending: "Отправка...",
 } as const;
 export default ru;

--- a/src/context/translations/types.ts
+++ b/src/context/translations/types.ts
@@ -112,6 +112,12 @@ export interface Translations {
   europeanUnion: string;
   unitedKingdom: string;
   philippines: string;
+  multipleProducts: string;
+  formFillRequired: string;
+  formInvalidEmail: string;
+  formSuccess: string;
+  formError: string;
+  formSending: string;
 }
 
 export type TranslationsKeys = keyof Translations;


### PR DESCRIPTION
## Summary
- Opciones \"Horse Meat\" y \"Multiple Products\" del selector ahora usan el sistema de traducciones (EN, ES, CN, RU)
- Reemplazados los `alert()` por mensajes inline dentro del formulario (error de validación, éxito, error de envío)
- Botón muestra estado \"Sending...\" y se deshabilita mientras envía
- Validación server-side en `/api/email`: verifica `name`, `email` y `message` antes de llamar a nodemailer (retorna 400 si inválido)
- Transporter de nodemailer movido fuera de la función para no recrearlo en cada request

## Test plan
- [x] Cambiar idioma y verificar que las opciones del selector se traducen
- [x] Enviar formulario con campos vacíos → mensaje de error inline
- [x] Enviar con email inválido → mensaje de error inline
- [x] Enviar correctamente → botón muestra \"Sending...\", luego mensaje de éxito
- [x] POST directo a `/api/email` con payload vacío → respuesta 400